### PR TITLE
Make configure-azmon-grafana.sh can be run standalone

### DIFF
--- a/.github/workflows/build-monitoring.yaml
+++ b/.github/workflows/build-monitoring.yaml
@@ -46,4 +46,4 @@ jobs:
     - name: Create Azure Monitor and Grafana resources
       run: bash ${GITHUB_WORKSPACE}/scripts/configure-azmon-grafana.sh -v $vmName -g $resourceGroup -m $monitorName -d $grafanaName -c $clusterName
     - name: Configure hostmemusage collection
-      run: bash ${GITHUB_WORKSPACE}/scripts/configure-vm-hostmemusage-collector.sh -g $resourceGroup -v $vmName -l $logAnalytics -m $monitorName
+      run: bash ${GITHUB_WORKSPACE}/scripts/configure-vm-hostmemusage-collector.sh -g $resourceGroup -l $logAnalytics -m $monitorName


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Remove the unused mandatory parameter 'vmName'.
* Allow users to specify a different resource group for the Azure Arc Cluster if necessary.
* Adjust the RBAC assignment for Grafana identity at the resource group level instead of the subscription level to meet the principle of least privilege.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
